### PR TITLE
Fix dependencies & versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 This is the code used for the paper [Towards Learning Universal Hyperparameter Optimizers with Transformers (NeurIPS 2022)](https://arxiv.org/abs/2205.13320).
 
 # Installation
-All base dependencies can be installed from `requirements.txt`. Afterwards, [T5X](https://github.com/google-research/t5x) must be manually installed.
+To get started, manually install [T5X](https://github.com/google-research/t5x). Afterwards, install OptFormer with ``pip install -e .``.
+
+
 
 # Usage
 

--- a/optformer/t5x/policies.py
+++ b/optformer/t5x/policies.py
@@ -387,9 +387,8 @@ class OptFormerDesigner(vza.Designer):
     return max_funs
 
   def update(
-      self, completed: vza.CompletedTrials, all_active: vza.ActiveTrials
+      self, completed: vza.CompletedTrials
   ) -> None:
-    del all_active
     completed_trials = []
     for trial in completed.trials:
       # A completed trial either has a final_measurement or is marked as

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
 # T5X prerequisite.
-seqio  # Always compatible with most up-to-date version.
+t5
+seqio==0.0.13  # Always compatible with most up-to-date version.
 
 # OSS Vizier
-google-vizier # Use latest version.
+google-vizier==0.0.20 # Use latest version.
 
 # Proto
 protobuf>=3.6,<4.0
+
+# For the notebook
+matplotlib
 
 # Autodiff and numerical packages.
 numpy>=1.21.5

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def _strip_comments_from_line(s: str) -> str:
   return requirement.strip()
 
 
-def _parse_requirements(requirements_txt_path: str) -> list[str]:
+def _parse_requirements(requirements_txt_path: str):
   """Returns a list of dependencies for setup() from requirements.txt."""
 
   with open(requirements_txt_path) as fp:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def _strip_comments_from_line(s: str) -> str:
   return requirement.strip()
 
 
-def _parse_requirements(requirements_txt_path: str):
+def _parse_requirements(requirements_txt_path: str) -> list[str]:
   """Returns a list of dependencies for setup() from requirements.txt."""
 
   with open(requirements_txt_path) as fp:


### PR DESCRIPTION
This PR fixes #30 by setting versions of ``seqio`` and ``google-vizier`` to ``0.0.13`` and ``0.0.20`` respectively. 